### PR TITLE
ci: removing clirr from required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -32,7 +32,6 @@ branchProtectionRules:
     - "dependencies (8)"
     - "dependencies (11)"
     - "lint"
-    - "clirr"
     - "units (8)"
     - "units (11)"
     - "Kokoro - Test: Integration"


### PR DESCRIPTION
Making CLIRR not required. The version bumps are now controlled by the Release Please and OwlBot. The CL authors create appropriate change description to control major version bumps.